### PR TITLE
Mark "Show link to XLS format" cuke as wip

### DIFF
--- a/features/xls_export_link.feature
+++ b/features/xls_export_link.feature
@@ -1,5 +1,6 @@
 Feature: Show link to XLS format below work package list
 
+  @wip
   Scenario: There is a link to the work package list in XML format
     Given there is a project named "Test Project"
     And I am already admin


### PR DESCRIPTION
API for plugins to export work package export dialog UI is not yet available.

(from an end-user perspective, this effectively disables XLS export)
