### PR TITLE
Feature: disable export formats

### DIFF
--- a/Gemfile.plugins
+++ b/Gemfile.plugins
@@ -2,6 +2,6 @@
 # The tested plugin will be moved to the path `./plugins/this`
 # whereas OpenProject will be checked out to `.`.
 
-gem 'openproject-xls', path: 'plugins/this'
+gem 'openproject-xls_export', path: 'plugins/this'
 
 # If the plugin has any dependencies declare them here:

--- a/Gemfile.plugins
+++ b/Gemfile.plugins
@@ -1,0 +1,7 @@
+# Used by travis to bundle this plugin with the OpenProject core.
+# The tested plugin will be moved to the path `./plugins/this`
+# whereas OpenProject will be checked out to `.`.
+
+gem 'openproject-xls', path: 'plugins/this'
+
+# If the plugin has any dependencies declare them here:

--- a/README.md
+++ b/README.md
@@ -33,6 +33,21 @@ from the file `Gemfile.plugins` and run:
 
 `bundle install`
 
+Configuration
+-------------
+
+The plugin adds 3 export formats to the work package index. They are all enabled by default.
+However, they can be disabled via the OpenProject configuration (`configuration.yml`):
+
+```
+  default:
+    xls_export:
+      disabled_formats:
+        - xls
+        - xls_with_descriptions
+        - xls_with_relations
+```
+
 Bug Reporting
 -------------
 

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -4,3 +4,8 @@ de:
   sentence_separator_or: "oder"
   different_formats: Andere Formate
   xls_with_descriptions: XLS mit Beschreibungen
+  xls_with_relations: XLS mit Beziehungen
+
+  xls_export:
+    child_of: untergeordnetes AP von
+    parent_of: übergeordnetes AP von

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,8 +4,8 @@ en:
   sentence_separator_or: "or"
   different_formats: Different formats
   label_xls: XLS
-  label_xls_with_descriptions: XLS with Descriptions
-  label_xls_with_relations: XLS with Relations
+  label_xls_with_descriptions: XLS with descriptions
+  label_xls_with_relations: XLS with relations
 
   xls_export:
     child_of: child of

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,4 +3,10 @@ en:
   print_with_description: "Print preview with description"
   sentence_separator_or: "or"
   different_formats: Different formats
-  xls_with_descriptions: XLS with Descriptions
+  label_xls: XLS
+  label_xls_with_descriptions: XLS with Descriptions
+  label_xls_with_relations: XLS with Relations
+
+  xls_export:
+    child_of: child of
+    parent_of: parent of

--- a/config/locales/js-de.yml
+++ b/config/locales/js-de.yml
@@ -2,3 +2,4 @@ de:
   js:
     label_format_xls: "XLS"
     label_format_xls_with_descriptions: "XLS mit Beschreibungen"
+    label_format_xls_with_relations: "XLS mit Beziehungen"

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -2,3 +2,4 @@ en:
   js:
     label_format_xls: "XLS"
     label_format_xls_with_descriptions: "XLS with descriptions"
+    label_format_xls_with_relations: "XLS with Relations"

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -2,4 +2,4 @@ en:
   js:
     label_format_xls: "XLS"
     label_format_xls_with_descriptions: "XLS with descriptions"
-    label_format_xls_with_relations: "XLS with Relations"
+    label_format_xls_with_relations: "XLS with relations"

--- a/lib/open_project/xls_export/engine.rb
+++ b/lib/open_project/xls_export/engine.rb
@@ -11,6 +11,12 @@ module OpenProject::XlsExport
     patches [:WorkPackagesController, :QueryColumn]
     # disabled since not yet migrated: :CostReportsController
 
+    initializer 'xls_export.mixins' do
+      require_relative 'patches/api/experimental/export_formats'
+
+      Api::Experimental::WorkPackagesController.prepend OpenProject::XlsExport::ExportFormats
+    end
+
     initializer 'xls_export.register_hooks' do
       # don't use require_dependency to not reload hooks in development mode
 

--- a/lib/open_project/xls_export/hooks/work_package_hook.rb
+++ b/lib/open_project/xls_export/hooks/work_package_hook.rb
@@ -2,12 +2,22 @@ module PrintableIssues
   class IssueHook  < Redmine::Hook::ViewListener
     # Add XLS format link below issue list
     def view_work_packages_index_other_formats(context)
-      (context[:link_formatter].link_to 'XLS', :url => { :project_id => context[:project] }) +
-      ' ' +
-      (context[:link_formatter].link_to I18n.t(:xls_with_descriptions),
-                                        :url => { :project_id => context[:project],
-                                                  :show_descriptions => true,
-                                                  :format => 'xls' })
+      links = [
+        link_to_xls(I18n.t(:label_xls), context),
+        link_to_xls(I18n.t(:label_xls_with_descriptions), context, show_descriptions: true),
+        link_to_xls(I18n.t(:label_xls_with_relations), context, show_relations: true)
+      ]
+
+      links.join(" ")
+    end
+
+    def link_to_xls(context, label, options = {})
+      url = {
+        project_id: context[:project],
+        format: "xls"
+      }
+
+      context[:link_formatter].link_to label, url: url.merge(options)
     end
   end
 end

--- a/lib/open_project/xls_export/patches/api/experimental/export_formats.rb
+++ b/lib/open_project/xls_export/patches/api/experimental/export_formats.rb
@@ -1,0 +1,44 @@
+module OpenProject
+  module XlsExport
+    ##
+    # Mix into Api::Experimental::WorkPackagesController to add
+    # the XLS export formats to the export dialog of the core.
+    module ExportFormats
+      def export_formats
+        formats = xls_export_formats.reject do |entry|
+          xls_export_disabled_formats.any? { |f| entry[:label_locale] =~ /#{f}$/}
+        end
+
+        super + formats
+      end
+
+      module_function
+
+      ##
+      # Supported values are:
+      #   - xls
+      #   - xls_with_descriptions
+      #   - xls_with_relations
+      def xls_export_disabled_formats
+        Array(Hash(OpenProject::Configuration['xls_export'])['disabled_formats'])
+      end
+
+      ##
+      # Note: identifier is used to construct the CSS class of the menu entry which
+      #       is relevant for the used icon.
+      def xls_export_formats
+        [
+          { identifier: 'xls', format: 'xls', label_locale: 'label_format_xls' },
+          {
+            identifier: 'xls-descr', format: 'xls',
+            label_locale: 'label_format_xls_with_descriptions', flags: ['show_descriptions']
+          },
+          {
+            identifier: 'xls', format: 'xls',
+            label_locale: 'label_format_xls_with_relations', flags: ['show_relations']
+          }
+        ]
+      end
+    end
+  end
+end

--- a/lib/open_project/xls_export/patches/work_packages_controller_patch.rb
+++ b/lib/open_project/xls_export/patches/work_packages_controller_patch.rb
@@ -29,18 +29,8 @@ module OpenProject::XlsExport
           params["format"].to_s.downcase == "xls"
         end
 
-        def show_relations?
-          params[:show_relations]
-        end
-
         def xls_export_associations
-          associations = [:assigned_to, :type, :priority, :category, :fixed_version]
-
-          if show_relations?
-            associations + [:relations]
-          else
-            associations
-          end
+          [:assigned_to, :type, :priority, :category, :fixed_version]
         end
 
         def xls_export_results(query)

--- a/lib/open_project/xls_export/work_package_xls_export.rb
+++ b/lib/open_project/xls_export/work_package_xls_export.rb
@@ -206,7 +206,7 @@ module OpenProject
 
       def work_package_relations(work_package)
         work_package.relations.select do |rel|
-          rel.other_work_package(work_package).visible?
+          rel.other_work_package(work_package).visible? current_user
         end
       end
     end

--- a/lib/open_project/xls_export/work_package_xls_export.rb
+++ b/lib/open_project/xls_export/work_package_xls_export.rb
@@ -157,9 +157,11 @@ module OpenProject
       #               that the respective work package is either a
       #               parent or a child.
       def related_work_packages(work_package)
-        family = [work_package.parent].compact + work_package.leaves
+        family = ([work_package.parent].compact + work_package.leaves)
+          .select { |wp| wp.visible? current_user }
+          .map { |wp| [wp, nil] }
 
-        family.map { |wp| [wp, nil] } + relation_work_packages(work_package)
+        family + relation_work_packages(work_package)
       end
 
       ##

--- a/lib/open_project/xls_export/work_package_xls_export.rb
+++ b/lib/open_project/xls_export/work_package_xls_export.rb
@@ -191,7 +191,7 @@ module OpenProject
           relation.relation_type_for work_package
         elsif work_package.parent_id == other.id
           I18n.t 'xls_export.child_of'
-        elsif work_package.leaves.where(id: other.id)
+        elsif work_package.leaves.where(id: other.id).exists?
           I18n.t 'xls_export.parent_of'
         end
       end

--- a/lib/open_project/xls_export/work_package_xls_export.rb
+++ b/lib/open_project/xls_export/work_package_xls_export.rb
@@ -1,0 +1,214 @@
+module OpenProject
+  module XlsExport
+    class WorkPackageXlsExport
+      attr_reader :project, :work_packages, :query, :current_user
+
+      def initialize(
+        project:, work_packages:, query:, current_user:,
+        with_descriptions: false, with_relations: false
+      )
+        @project = project
+        @work_packages = work_packages
+        @query = query
+        @current_user = current_user
+
+        enable! WithTimeZone
+        enable! WithDescription if with_descriptions
+        enable! WithRelations if with_relations
+      end
+
+      def enable!(singleton_module)
+        self.singleton_class.prepend singleton_module
+      end
+
+      def to_xls
+        spreadsheet.xls
+      end
+
+      def spreadsheet
+        sb = spreadsheet_builder
+
+        add_headers! sb
+        add_rows! sb
+        set_column_format_options! sb
+
+        sb
+      end
+
+      def add_headers!(spreadsheet)
+        spreadsheet.add_headers headers, 0
+      end
+
+      def add_rows!(spreadsheet)
+        rows.each do |row|
+          spreadsheet.add_row row
+        end
+      end
+
+      def rows
+        work_packages.map do |work_package|
+          row work_package
+        end
+      end
+
+      def row(work_package)
+        columns.collect do |column|
+          column_value column, work_package
+        end
+      end
+
+      def column_value(column, work_package)
+        value = format_column_value column, work_package
+
+        value.respond_to?(:name) ? value.name : value
+      end
+
+      def format_column_value(column, work_package)
+        formatters[column].format work_package, column
+      end
+
+      def set_column_format_options!(spreadsheet)
+        columns.each_with_index do |column, i|
+          options = formatters[column].format_options column
+
+          spreadsheet.add_format_option_to_column i, options
+        end
+      end
+
+      def columns
+        @columns ||= query.columns
+      end
+
+      def formatters
+        @formatters ||= OpenProject::XlsExport::Formatters.for_columns(columns)
+      end
+
+      def spreadsheet_builder
+        SpreadsheetBuilder.new I18n.t(:label_work_package_plural)
+      end
+
+      def headers
+        columns.map(&:caption)
+      end
+    end
+
+    module WithTimeZone
+      def format_column_value(column, work_package)
+        value = super
+
+        if value.is_a? ActiveSupport::TimeWithZone
+          value.in_time_zone current_user.time_zone
+        else
+          value
+        end
+      end
+    end
+
+    module WithDescription
+      def headers
+        super + [WorkPackage.human_attribute_name(:description)]
+      end
+
+      def row(work_package)
+        super + [work_package.description]
+      end
+    end
+
+    module WithRelations
+      def add_headers!(spreadsheet)
+        headers_0 = [I18n.t(:label_work_package_plural)] +
+          columns.size.times.map { |_| "" } +
+          [I18n.t("js.work_packages.tabs.relations")]
+
+        spreadsheet.add_headers headers_0, 0
+        spreadsheet.add_headers headers, 1
+      end
+
+      def headers
+        [""] + super + [""] + with_relations_headers
+      end
+
+      def rows
+        super.flatten(1) # since we will now generate several rows for each original row
+      end
+
+      def row(work_package)
+        wp_columns = super
+
+        relatives = related_work_packages work_package
+
+        if relatives.size > 0
+          relatives.map do |other, rel|
+            relation_row work_package, wp_columns, other, rel
+          end
+        else
+          unrelated_row wp_columns
+        end
+      end
+
+      module_function
+
+      ##
+      # Work packages both related explicitly through relation records
+      # as well via their parent_id association (parent and children).
+      #
+      # @return Array A list of work package - relation tuples
+      #               where the relation may be nil which indicates
+      #               that the respective work package is either a
+      #               parent or a child.
+      def related_work_packages(work_package)
+        family = [work_package.parent].compact + work_package.leaves
+
+        family.map { |wp| [wp, nil] } + relation_work_packages(work_package)
+      end
+
+      ##
+      # Work packages related through explicit relation records.
+      #
+      # @return Array<Array<WorkPackage, Relation>> A list of work package - relation tuples.
+      def relation_work_packages(work_package)
+        relations = work_package_relations work_package
+
+        relations.map { |rel| [rel.other_work_package(work_package), rel] }
+      end
+
+      def unrelated_row(wp_columns)
+        [([""] + wp_columns)]
+      end
+
+      def relation_row(work_package, wp_columns, other, relation)
+        type = relation_type work_package, other, relation
+        delay = relation ? relation.delay : ""
+        relation_columns = ["", type, delay, other.id, other.type.name, other.subject]
+
+        [""] + wp_columns + relation_columns
+      end
+
+      def relation_type(work_package, other, relation)
+        if relation
+          relation.relation_type_for work_package
+        elsif work_package.parent_id == other.id
+          I18n.t 'xls_export.child_of'
+        elsif work_package.leaves.where(id: other.id)
+          I18n.t 'xls_export.parent_of'
+        end
+      end
+
+      def with_relations_headers
+        [
+          Relation.human_attribute_name(:relation_type),
+          Relation.human_attribute_name(:delay),
+          WorkPackage.human_attribute_name(:id),
+          WorkPackage.human_attribute_name(:type),
+          WorkPackage.human_attribute_name(:subject)
+        ]
+      end
+
+      def work_package_relations(work_package)
+        work_package.relations.select do |rel|
+          rel.other_work_package(work_package).visible?
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/work_package_xls_export_spec.rb
+++ b/spec/lib/work_package_xls_export_spec.rb
@@ -1,0 +1,183 @@
+require 'spec_helper'
+require 'spreadsheet'
+
+describe "WorkPackageXlsExport" do
+  let(:project) { FactoryGirl.create :project }
+
+  let(:parent) { FactoryGirl.create :work_package, project: project, subject: 'Parent' }
+  let(:child_1) do
+    FactoryGirl.create :work_package, parent: parent, project: project, subject: 'Child 1'
+  end
+  let(:child_2) do
+    FactoryGirl.create :work_package, parent: parent, project: project, subject: 'Child 2'
+  end
+
+  let(:single) { FactoryGirl.create :work_package, project: project, subject: 'Single' }
+  let(:followed) { FactoryGirl.create :work_package, project: project, subject: 'Followed' }
+
+  let(:relation) do
+    child_2.new_relation.tap do |r|
+      r.to = followed
+      r.relation_type = 'follows'
+      r.delay = 0
+      r.save
+    end
+  end
+
+  let(:work_packages) do
+    [parent, child_1, child_2, single, followed]
+  end
+
+  let(:current_user) { FactoryGirl.create :admin } # may export relations
+
+  let(:query) { FactoryGirl.create :query }
+
+  let(:sheet) do
+    work_packages
+    relation
+    work_packages.each(&:reload) # to init .leaves and relations
+
+    load_sheet export
+  end
+
+  let(:export) do
+    OpenProject::XlsExport::WorkPackageXlsExport.new(
+      project: project, work_packages: work_packages, query: query,
+      current_user: current_user,
+      with_relations: true
+    )
+  end
+
+  def load_sheet(export)
+    f = Tempfile.new 'result.xls'
+    begin
+      f.binmode
+      f.write export.to_xls
+    ensure
+      f.close
+    end
+
+    sheet = Spreadsheet.open(f.path).worksheets.first
+    f.unlink
+
+    sheet
+  end
+
+  describe 'query' do
+    it 'is the default query (the rest of the specs relies on this)' do
+      expect(query.columns.map(&:name)).to eq [:id, :subject, :type, :status, :assigned_to]
+    end
+  end
+
+  it 'writes 9 rows' do
+    expect(sheet.rows.size).to eq 9 # 2 header rows + 7 content rows
+  end
+
+  it 'the first header row devides the sheet into work packages and relation columns' do
+    expect(sheet.rows.first.take(7))
+      .to eq ['Work packages', nil, nil, nil, nil, nil, 'Relations']
+  end
+
+  it 'the second header row includes the column names for work packages and relations' do
+    expect(sheet.rows[1])
+      .to eq [
+        nil, 'ID', 'Subject', 'Type', 'Status', 'Assignee',
+        nil, 'Relation type', 'Delay', 'ID', 'Type', 'Subject',
+        nil
+      ]
+  end
+
+  it 'duplicates rows for each relation' do
+    expect(sheet.column(1).drop(2))
+      .to eq [
+        parent.id, parent.id, child_1.id, child_2.id, child_2.id, single.id, followed.id
+      ]
+  end
+
+  # expected row and column indices
+
+  PARENT = 2
+  CHILD_1 = 4
+  CHILD_2 = 5
+  SINGLE = 7
+  FOLLOWED = 8
+  RELATION = 7
+  RELATED_SUBJECT = 11
+
+  it 'marks Parent as parent of Child 1 and 2' do
+    expect(sheet.row(PARENT)[RELATION]).to eq 'parent of'
+    expect(sheet.row(PARENT)[RELATED_SUBJECT]).to eq 'Child 1'
+
+    expect(sheet.row(PARENT + 1)[RELATION]).to eq 'parent of'
+    expect(sheet.row(PARENT + 1)[RELATED_SUBJECT]).to eq 'Child 2'
+  end
+
+  it 'shows Child 1 as child of Parent' do
+    expect(sheet.row(CHILD_1)[RELATION]).to eq 'child of'
+    expect(sheet.row(CHILD_1)[RELATED_SUBJECT]).to eq 'Parent'
+  end
+
+  it 'shows Child 2 as child of Parent' do
+    expect(sheet.row(CHILD_2)[RELATION]).to eq 'child of'
+    expect(sheet.row(CHILD_2)[RELATED_SUBJECT]).to eq 'Parent'
+  end
+
+  it 'shows Child 2 as following Followed' do
+    expect(sheet.row(CHILD_2 + 1)[RELATION]).to eq 'follows'
+    expect(sheet.row(CHILD_2 + 1)[RELATED_SUBJECT]).to eq 'Followed'
+  end
+
+  it 'shows no relation information for Single' do
+    expect(sheet.row(SINGLE).drop(6).compact).to eq []
+  end
+
+  it 'shows Followed as preceding Child 2' do
+    expect(sheet.row(FOLLOWED)[RELATION]).to eq 'precedes'
+    expect(sheet.row(FOLLOWED)[RELATED_SUBJECT]).to eq 'Child 2'
+  end
+
+  it 'exports the correct data (examples)' do
+    expect(sheet.row(PARENT))
+      .to eq [
+        nil, parent.id, parent.subject, parent.type.name, parent.status.name, parent.assigned_to,
+        nil, 'parent of', nil, child_1.id, child_1.type.name, child_1.subject
+      ] # delay nil as this is a parent-child relation not represented by an actual Relation record
+
+    expect(sheet.row(SINGLE))
+      .to eq [
+        nil, single.id, single.subject, single.type.name, single.status.name, single.assigned_to
+      ]
+
+    expect(sheet.row(FOLLOWED))
+      .to eq [
+        nil, followed.id, followed.subject, followed.type.name, followed.status.name,
+          followed.assigned_to,
+        nil, 'precedes', 0, child_2.id, child_2.type.name, child_2.subject
+      ]
+  end
+
+  context 'with someone who may not see related work packages' do
+    # Technically not allowed to see any of the work packages.
+    # The export only checks for related work packages, though.
+    # It's not the export's responsibility to check that the passed
+    # work packages may be seen.
+    let(:current_user) { FactoryGirl.create :user }
+
+    it 'shows each work package only once' do
+      expect(sheet.column(1).drop(2))
+        .to eq [
+          parent.id, child_1.id, child_2.id, single.id, followed.id
+        ]
+    end
+
+    it 'shows no relation information' do
+      relation_data = sheet.rows
+        .drop(2) # drop headers
+        .map { |row| row.drop(6) } # leave only relation columns
+        .flatten
+        .compact
+
+      expect(relation_data).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
WP [#23693](https://community.openproject.com/work_packages/23693/activity)

Allows disabling the "XLS with relations" export format via the OpenProject configuration.
For instance by defining the following environment variable:

```
OPENPROJECT_XLS__EXPORT_DISABLED__FORMATS='["xls_with_relations"]'
```
