### PR TITLE
actually define xls export formats in plugin; allow disabling them too

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,21 @@ from the file `Gemfile.plugins` and run:
 
 `bundle install`
 
+Configuration
+-------------
+
+The plugin adds 3 export formats to the work package index. They are all enabled by default.
+However, they can be disabled via the OpenProject configuration (`configuration.yml`):
+
+```
+  default:
+    xls_export:
+      disabled_formats:
+        - xls
+        - xls_with_descriptions
+        - xls_with_relations
+```
+
 Bug Reporting
 -------------
 

--- a/lib/open_project/xls_export/engine.rb
+++ b/lib/open_project/xls_export/engine.rb
@@ -11,6 +11,12 @@ module OpenProject::XlsExport
     patches [:WorkPackagesController, :QueryColumn]
     # disabled since not yet migrated: :CostReportsController
 
+    initializer 'xls_export.mixins' do
+      require_relative 'patches/api/experimental/export_formats'
+
+      Api::Experimental::WorkPackagesController.prepend OpenProject::XlsExport::ExportFormats
+    end
+
     initializer 'xls_export.register_hooks' do
       # don't use require_dependency to not reload hooks in development mode
 

--- a/lib/open_project/xls_export/patches/api/experimental/export_formats.rb
+++ b/lib/open_project/xls_export/patches/api/experimental/export_formats.rb
@@ -1,0 +1,44 @@
+module OpenProject
+  module XlsExport
+    ##
+    # Mix into Api::Experimental::WorkPackagesController to add
+    # the XLS export formats to the export dialog of the core.
+    module ExportFormats
+      def export_formats
+        formats = xls_export_formats.reject do |entry|
+          xls_export_disabled_formats.any? { |f| entry[:label_locale] =~ /#{f}$/}
+        end
+
+        super + formats
+      end
+
+      module_function
+
+      ##
+      # Supported values are:
+      #   - xls
+      #   - xls_with_descriptions
+      #   - xls_with_relations
+      def xls_export_disabled_formats
+        Array(Hash(OpenProject::Configuration['xls_export'])['disabled_formats'])
+      end
+
+      ##
+      # Note: identifier is used to construct the CSS class of the menu entry which
+      #       is relevant for the used icon.
+      def xls_export_formats
+        [
+          { identifier: 'xls', format: 'xls', label_locale: 'label_format_xls' },
+          {
+            identifier: 'xls-descr', format: 'xls',
+            label_locale: 'label_format_xls_with_descriptions', flags: ['show_descriptions']
+          },
+          {
+            identifier: 'xls', format: 'xls',
+            label_locale: 'label_format_xls_with_relations', flags: ['show_relations']
+          }
+        ]
+      end
+    end
+  end
+end


### PR DESCRIPTION
WP [#23693](https://community.openproject.com/work_packages/23693/activity)

Allows disabling the "XLS with relations" export format via the OpenProject configuration.
For instance by defining the following environment variable:

```
OPENPROJECT_XLS__EXPORT_DISABLED__FORMATS='["xls_with_relations"]'
```
