### PR TITLE
reenable xls export on wp collection

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -3,8 +3,12 @@ de:
   export_to_excel: "Exportieren als Excel Spreadsheet"
   sentence_separator_or: "oder"
   different_formats: Andere Formate
-  xls_with_descriptions: XLS mit Beschreibungen
-  xls_with_relations: XLS mit Beziehungen
+
+  export:
+    format:
+      xls: "XLS"
+      xls_with_descriptions: "XLS mit Beschreibungen"
+      xls_with_relations: "XLS mit Beziehungen"
 
   xls_export:
     child_of: untergeordnetes AP von

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,9 +3,12 @@ en:
   print_with_description: "Print preview with description"
   sentence_separator_or: "or"
   different_formats: Different formats
-  label_xls: XLS
-  label_xls_with_descriptions: XLS with descriptions
-  label_xls_with_relations: XLS with relations
+
+  export:
+    format:
+      xls: "XLS"
+      xls_with_descriptions: "XLS with descriptions"
+      xls_with_relations: "XLS with relations"
 
   xls_export:
     child_of: child of

--- a/config/locales/js-de.yml
+++ b/config/locales/js-de.yml
@@ -1,5 +1,0 @@
-de:
-  js:
-    label_format_xls: "XLS"
-    label_format_xls_with_descriptions: "XLS mit Beschreibungen"
-    label_format_xls_with_relations: "XLS mit Beziehungen"

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -1,5 +1,0 @@
-en:
-  js:
-    label_format_xls: "XLS"
-    label_format_xls_with_descriptions: "XLS with descriptions"
-    label_format_xls_with_relations: "XLS with relations"

--- a/lib/open_project/xls_export/engine.rb
+++ b/lib/open_project/xls_export/engine.rb
@@ -5,16 +5,16 @@ module OpenProject::XlsExport
     include OpenProject::Plugins::ActsAsOpEngine
 
     register 'openproject-xls_export',
-             :author_url => 'http://finn.de/',
-             :requires_openproject => '>= 4.0.0'
+             author_url: 'http://openproject.com/',
+             requires_openproject: '>= 4.0.0'
 
     patches [:WorkPackagesController, :QueryColumn]
     # disabled since not yet migrated: :CostReportsController
 
-    initializer 'xls_export.mixins' do
-      require_relative 'patches/api/experimental/export_formats'
+    extend_api_response(:v3, :work_packages, :work_package_collection) do
+      require_relative 'patches/api/v3/export_formats'
 
-      Api::Experimental::WorkPackagesController.prepend OpenProject::XlsExport::ExportFormats
+      prepend Patches::Api::V3::ExportFormats
     end
 
     initializer 'xls_export.register_hooks' do

--- a/lib/open_project/xls_export/hooks/work_package_hook.rb
+++ b/lib/open_project/xls_export/hooks/work_package_hook.rb
@@ -1,16 +1,5 @@
 module PrintableIssues
-  class IssueHook  < Redmine::Hook::ViewListener
-    # Add XLS format link below issue list
-    def view_work_packages_index_other_formats(context)
-      links = [
-        link_to_xls(I18n.t(:label_xls), context),
-        link_to_xls(I18n.t(:label_xls_with_descriptions), context, show_descriptions: true),
-        link_to_xls(I18n.t(:label_xls_with_relations), context, show_relations: true)
-      ]
-
-      links.join(" ")
-    end
-
+  class IssueHook < Redmine::Hook::ViewListener
     def link_to_xls(context, label, options = {})
       url = {
         project_id: context[:project],

--- a/lib/open_project/xls_export/patches/api/v3/export_formats.rb
+++ b/lib/open_project/xls_export/patches/api/v3/export_formats.rb
@@ -1,0 +1,30 @@
+module OpenProject::XlsExport::Patches
+  module Api::V3::ExportFormats
+    def representation_formats
+      super + [
+        representation_format_xls,
+        representation_format_xls_descriptions,
+        representation_format_xls_relations
+      ]
+    end
+
+    def representation_format_xls
+      representation_format('xls',
+                            'application/vnd.ms-excel')
+    end
+
+    def representation_format_xls_descriptions
+      representation_format('xls',
+                            'application/vnd.ms-excel',
+                            'xls_with_descriptions',
+                            'show_descriptions=true')
+    end
+
+    def representation_format_xls_relations
+      representation_format('xls',
+                            'application/vnd.ms-excel',
+                            'xls_with_relations',
+                            'show_relations=true')
+    end
+  end
+end

--- a/lib/open_project/xls_export/patches/work_packages_controller_patch.rb
+++ b/lib/open_project/xls_export/patches/work_packages_controller_patch.rb
@@ -34,7 +34,7 @@ module OpenProject::XlsExport
         end
 
         def xls_export_results(query)
-          query.results include: xls_export_associations, order: sort_clause
+          query.results include: xls_export_associations
         end
 
         def xls_export_filename
@@ -45,7 +45,7 @@ module OpenProject::XlsExport
 
         def define_xls_format!(format)
           format.xls do
-            @issues = xls_export_results(@query).work_packages
+            @work_packages = xls_export_results(@query).sorted_work_packages
             data = issues_to_xls params.slice(:show_descriptions, :show_relations)
 
             send_data data, type: "application/vnd.ms-excel", filename: xls_export_filename
@@ -55,7 +55,7 @@ module OpenProject::XlsExport
         # Return an xls file from a spreadsheet builder
         def issues_to_xls(options)
           export = OpenProject::XlsExport::WorkPackageXlsExport.new(
-            project: @project, work_packages: @issues, query: @query,
+            project: @project, work_packages: @work_packages, query: @query,
             current_user: current_user,
             with_descriptions: options[:show_descriptions],
             with_relations: options[:show_relations]


### PR DESCRIPTION
Adds the necessary representation links to the wp collection representer in order to be able to list the xls options in the export modals again.

Requires https://github.com/opf/openproject/pull/5219